### PR TITLE
Fix compiler error "operand type mismatch for 'bsf'" with default gcc-13 compiler on Ubuntu24.04

### DIFF
--- a/core/include/x86/bitwise.h
+++ b/core/include/x86/bitwise.h
@@ -19,7 +19,7 @@ static __inline__ prtos_s32_t _ffs(prtos_s32_t x) {
                          "movl $-1,%0\n"
                          "1:"
                          : "=r"(r)
-                         : "g"(x));
+                         : "r"(x));
     return r;
 }
 
@@ -33,7 +33,7 @@ static __inline__ prtos_s32_t _ffz(prtos_s32_t x) {
                          "movl $-1,%0\n"
                          "1:"
                          : "=r"(r)
-                         : "g"(~x));
+                         : "r"(~x));
     return r;
 }
 
@@ -47,7 +47,7 @@ static __inline__ prtos_s32_t _fls(prtos_s32_t x) {
                          "movl $-1,%0\n"
                          "1:"
                          : "=r"(r)
-                         : "g"(x));
+                         : "r"(x));
     return r;
 }
 


### PR DESCRIPTION
This compile error only happens with inlined asm option "-g", I think it is a bug of gcc-13 compiler. 
Current WA is to change "-g" to "-r" for inlined asm code.

Signed-off-by: 18939117 <18939117@qq.com>
