### PR TITLE
[amd64][qemu] add ACPI support for virtio Linux in demo partitions  of shown case `virtio_linux_demo_2p_amd64`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,14 @@ make
 cd user/bail/examples/virtio_linux_demo_2p_amd64
 make run.amd64
 ```
-This launches QEMU with dual consoles:
-- **System Partition** (COM1/stdio): login `root`/`1234`, then run `prtos_manager &` and `virtio_backend &`
-- **Guest Partition** (COM2/telnet): `telnet localhost 4321`, login `root`/`1234`
-- **Guest VGA** (VNC): `vnc://localhost:5901`
+This launches QEMU with three access points:
+- **Terminal** (this window): System Partition COM1 login (`root`/`1234`)
+- **VNC** `vnc://localhost:5901`: Guest Partition VGA display
+- **Telnet** `telnet localhost 4321`: Guest Partition COM2 login (`root`/`1234`)
+
+All virtio services auto-start via init scripts (`S99virtio_backend` on System, `S99virtio_guest` on Guest). No manual steps are required.
+
+The backend detects Guest partition halt and automatically disconnects TCP clients with a notification message.
 
 See `user/bail/examples/virtio_linux_demo_2p_amd64/README.md` for full documentation.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -215,12 +215,42 @@ make
 cd user/bail/examples/virtio_linux_demo_2p_amd64
 make run.amd64
 ```
-该命令启动 QEMU 并提供三个控制台访问方式：
-- **系统分区** (COM1/stdio)：当前终端登录，用户名 `root`，密码 `1234`，然后运行 `prtos_manager &` 和 `virtio_backend &`
-- **客户分区** (COM2/telnet)：`telnet localhost 4321`，用户名 `root`，密码 `1234`
-- **客户VGA** (VNC)：`vnc://localhost:5901`
+该命令启动 QEMU 并提供三个访问方式：
+- **终端**（当前窗口）：系统分区 COM1 登录（`root`/`1234`）
+- **VNC** `vnc://localhost:5901`：客户分区 VGA 显示
+- **Telnet** `telnet localhost 4321`：客户分区 COM2 登录（`root`/`1234`）
+
+所有 virtio 服务通过 init 脚本自动启动（系统分区 `S99virtio_backend`，客户分区 `S99virtio_guest`），无需手动操作。
+
+后端会检测客户分区停止（halt）状态，并自动断开 TCP 客户端连接，发送通知消息。
 
 详细文档参见 `user/bail/examples/virtio_linux_demo_2p_amd64/README.md`。
+
+#### 6.5.4 PRTOS 编译和运行 `virtio_linux_demo_2p_aarch64`（双 SMP Linux + Virtio 设备虚拟化）
+```
+cd prtos-hypervisor
+cp prtos_config.aarch64 prtos_config
+make defconfig
+make
+cd user/bail/examples/virtio_linux_demo_2p_aarch64
+make run.aarch64
+```
+系统分区 PL011 UART 控制台通过 stdio 输出。用户名 `root`，密码 `1234`。
+
+详细文档参见 `user/bail/examples/virtio_linux_demo_2p_aarch64/README.md`。
+
+#### 6.5.5 PRTOS 编译和运行 `virtio_linux_demo_2p_riscv64`（双 SMP Linux + Virtio 设备虚拟化）
+```
+cd prtos-hypervisor
+cp prtos_config.riscv64 prtos_config
+make defconfig
+make
+cd user/bail/examples/virtio_linux_demo_2p_riscv64
+make run.riscv64
+```
+系统分区 NS16550 UART 控制台通过 stdio 输出。用户名 `root`，密码 `1234`。
+
+详细文档参见 `user/bail/examples/virtio_linux_demo_2p_riscv64/README.md`。
 
 ## 7. 测试
 
@@ -288,9 +318,11 @@ The test report of run `bash scripts/run_test.sh --arch x86 check-all` should be
   mix_os_demo_aarch64  SKIP
   mix_os_demo_riscv64  SKIP
   mix_os_demo_amd64    SKIP
+  virtio_linux_demo_2p_aarch64 SKIP
+  virtio_linux_demo_2p_riscv64 SKIP
   virtio_linux_demo_2p_amd64 SKIP
 --------------------------------------
-  Total: 25  Pass: 11  Fail: 0  Skip: 14
+  Total: 27  Pass: 11  Fail: 0  Skip: 16
 ======================================
 
 ```
@@ -325,9 +357,11 @@ The test report of run `bash scripts/run_test.sh --arch aarch64 check-all` shoul
   mix_os_demo_aarch64  PASS
   mix_os_demo_riscv64  SKIP
   mix_os_demo_amd64    SKIP
+  virtio_linux_demo_2p_aarch64 PASS
+  virtio_linux_demo_2p_riscv64 SKIP
   virtio_linux_demo_2p_amd64 SKIP
 --------------------------------------
-  Total: 25  Pass: 16  Fail: 0  Skip: 9
+  Total: 27  Pass: 17  Fail: 0  Skip: 10
 ======================================
 ```
 
@@ -360,9 +394,11 @@ The test report of run `bash scripts/run_test.sh --arch riscv64 check-all` shoul
   mix_os_demo_aarch64  SKIP
   mix_os_demo_riscv64  PASS
   mix_os_demo_amd64    SKIP
+  virtio_linux_demo_2p_aarch64 SKIP
+  virtio_linux_demo_2p_riscv64 PASS
   virtio_linux_demo_2p_amd64 SKIP
 --------------------------------------
-  Total: 25  Pass: 15  Fail: 0  Skip: 10
+  Total: 27  Pass: 16  Fail: 0  Skip: 11
 ======================================
 ```
 
@@ -395,9 +431,11 @@ The test report of run `bash scripts/run_test.sh --arch amd64 check-all` should 
   mix_os_demo_aarch64  SKIP
   mix_os_demo_riscv64  SKIP
   mix_os_demo_amd64    PASS
+  virtio_linux_demo_2p_aarch64 SKIP
+  virtio_linux_demo_2p_riscv64 SKIP
   virtio_linux_demo_2p_amd64 PASS
 --------------------------------------
-  Total: 25  Pass: 16  Fail: 0  Skip: 9
+  Total: 27  Pass: 16  Fail: 0  Skip: 11
 ======================================
 ```
 

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -1194,6 +1194,7 @@ cmd = (f"{sg_pre}qemu-system-x86_64 "
        "-nographic -no-reboot "
        "-cdrom resident_sw.iso "
        "-serial mon:stdio "
+       "-nic none "
        f"-boot d{sg_post}")
 child = pexpect.spawn('/bin/bash', ['-c', cmd],
                       timeout=460, encoding='utf-8', codec_errors='replace')

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/Makefile
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/Makefile
@@ -140,13 +140,16 @@ prtos_manager: $(MGR_OBJS)
 # ============================================================================
 
 rootfs_overlay.cpio: prtos_manager virtio_backend \
-                     system_partition/rootfs_overlay/etc/init.d/S99virtio_backend
+                     system_partition/rootfs_overlay/etc/init.d/S99virtio_backend \
+                     system_partition/rootfs_overlay/etc/network/interfaces
 	@rm -rf _overlay_root
 	@mkdir -p _overlay_root/usr/bin
 	@mkdir -p _overlay_root/etc/init.d
+	@mkdir -p _overlay_root/etc/network
 	@cp prtos_manager  _overlay_root/usr/bin/
 	@cp virtio_backend _overlay_root/usr/bin/
 	@cp system_partition/rootfs_overlay/etc/init.d/S99virtio_backend _overlay_root/etc/init.d/
+	@cp system_partition/rootfs_overlay/etc/network/interfaces _overlay_root/etc/network/
 	@chmod 755 _overlay_root/usr/bin/prtos_manager
 	@chmod 755 _overlay_root/usr/bin/virtio_backend
 	@chmod 755 _overlay_root/etc/init.d/S99virtio_backend
@@ -171,14 +174,17 @@ virtio_frontend: guest_partition/src/virtio_frontend.c
 
 guest_rootfs_overlay.cpio: guest_partition/rootfs_overlay/opt/virtio_test.sh \
                            guest_partition/rootfs_overlay/etc/init.d/S99virtio_guest \
+                           guest_partition/rootfs_overlay/etc/network/interfaces \
                            set_serial_poll \
                            virtio_frontend
 	@rm -rf _guest_overlay_root
 	@mkdir -p _guest_overlay_root/opt
 	@mkdir -p _guest_overlay_root/etc/init.d
+	@mkdir -p _guest_overlay_root/etc/network
 	@mkdir -p _guest_overlay_root/usr/bin
 	@cp guest_partition/rootfs_overlay/opt/virtio_test.sh _guest_overlay_root/opt/
 	@cp guest_partition/rootfs_overlay/etc/init.d/S99virtio_guest _guest_overlay_root/etc/init.d/
+	@cp guest_partition/rootfs_overlay/etc/network/interfaces _guest_overlay_root/etc/network/
 	@cp set_serial_poll _guest_overlay_root/opt/
 	@cp virtio_frontend _guest_overlay_root/usr/bin/
 	@chmod 755 _guest_overlay_root/opt/virtio_test.sh
@@ -273,6 +279,7 @@ run.amd64:
 		-serial mon:stdio \
 		-serial telnet::4321,server,nowait \
 		-vga std -display none -vnc :1 \
+		-nic none \
 		-boot d
 
 # Nographic mode for automated testing (System UART only)
@@ -283,6 +290,7 @@ run.amd64.nographic:
 		-nographic -m 1024 -smp 4 \
 		-cdrom resident_sw.iso \
 		-serial mon:stdio \
+		-nic none \
 		-boot d
 
 # Alias for test framework
@@ -293,6 +301,7 @@ run.amd64.kvm.nographic:
 		-nographic -m 1024 -smp 4 \
 		-cdrom resident_sw.iso \
 		-serial mon:stdio \
+		-nic none \
 		-boot d
 
 # Full demo: Dual Console (UART + VGA + telnet) + PCI devices

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/config/resident_sw.xml
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/config/resident_sw.xml
@@ -19,15 +19,15 @@
       Virtio_Con:   256KB @ 0x16500000  (virtio-console)
 
   ACPI Hardware Description (provided by QEMU, accessible via EPT identity map):
-    RSDP:  0x000F5290 (in BIOS ROM area, e820 reserved 0xA0000-0xFFFFF)
-    ACPI Tables: 0x3FFE0000-0x3FFFFFFF (RSDT/FACP/DSDT/FACS/MADT/HPET/WAET)
+    RSDP:  Dynamic (scanned in BIOS ROM area 0xE0000-0xFFFFF by boot stub)
+    ACPI Tables: 0x3FF80000-0x3FFFFFFF (512KB, sized for PCI device configs)
       - MADT: SMP CPU topology (4 LAPIC entries), IOAPIC at 0xFEC00000
       - HPET: Timer at 0xFED00000 (MMIO via 3-4GB EPT UC identity map)
       - DSDT: PCI root bridge, ISA devices, power management
     ACPI PM Timer: I/O port 0x608 (PIIX4 ACPI controller, PM_TMR_BLK)
     Both partitions access ACPI tables via EPT first-1GB identity map.
-    boot_params.acpi_rsdp_addr set to 0xF5290 for Linux 5.2+ boot protocol.
-    e820 entry type 3 (ACPI reclaimable) at 0x3FFE0000 protects table memory.
+    Boot stub scans for "RSD PTR " signature; address varies with PCI config.
+    e820 entry type 3 (ACPI reclaimable) at 0x3FF80000 protects table memory.
 
   CPU Assignment (SMP, dedicated pCPU mapping):
     pCPU 0 -> System Partition vCPU 0

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/config/resident_sw.xml
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/config/resident_sw.xml
@@ -18,6 +18,17 @@
       Virtio_Blk:   2MB   @ 0x16300000  (virtio-blk file-backed)
       Virtio_Con:   256KB @ 0x16500000  (virtio-console)
 
+  ACPI Hardware Description (provided by QEMU, accessible via EPT identity map):
+    RSDP:  0x000F5290 (in BIOS ROM area, e820 reserved 0xA0000-0xFFFFF)
+    ACPI Tables: 0x3FFE0000-0x3FFFFFFF (RSDT/FACP/DSDT/FACS/MADT/HPET/WAET)
+      - MADT: SMP CPU topology (4 LAPIC entries), IOAPIC at 0xFEC00000
+      - HPET: Timer at 0xFED00000 (MMIO via 3-4GB EPT UC identity map)
+      - DSDT: PCI root bridge, ISA devices, power management
+    ACPI PM Timer: I/O port 0x608 (PIIX4 ACPI controller, PM_TMR_BLK)
+    Both partitions access ACPI tables via EPT first-1GB identity map.
+    boot_params.acpi_rsdp_addr set to 0xF5290 for Linux 5.2+ boot protocol.
+    e820 entry type 3 (ACPI reclaimable) at 0x3FFE0000 protects table memory.
+
   CPU Assignment (SMP, dedicated pCPU mapping):
     pCPU 0 -> System Partition vCPU 0
     pCPU 1 -> System Partition vCPU 1
@@ -41,6 +52,7 @@
     COM2 (0x2F8-0x2FF):  Guest VGA/telnet (passthrough by hypervisor)
     PCI  (0xCF8-0xCFF):  PCI config space
     VGA  (0x3B0-0x3DF):  Guest VGA display (passthrough by hypervisor)
+    ACPI PM (0x600-0x63F): ACPI power management (PM Timer at 0x608)
 
   Doorbell IPVI (Guest <-> System):
     IPVI 0: net0  (Guest src=1 -> System dst=0, vector 32)
@@ -145,6 +157,11 @@
                     <!-- DMA page registers (0x80-0x8F) -->
                     <Range base="0x80" noPorts="16" />
                     <!-- PIC 8259 slave (0xA0-0xA1): Reserved by PRTOS -->
+                    <!-- ACPI PM registers (PIIX4 ACPI controller, base 0x600):
+                         PM1a_EVT_BLK (0x600-0x603), PM1a_CNT_BLK (0x604-0x605),
+                         PM_TMR_BLK (0x608-0x60B), GPE0_BLK (0x60C-0x60F).
+                         PM Timer at 0x608 used as clocksource by Linux. -->
+                    <Range base="0x600" noPorts="64" />
                     <!-- COM1 UART: 0x3F8-0x3FC reserved by PRTOS, keep 0x3FD-0x3FF -->
                     <Range base="0x3FD" noPorts="3" />
                     <!-- PCI config space (0xCF8-0xCFF) -->

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/guest_partition/rootfs_overlay/etc/network/interfaces
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/guest_partition/rootfs_overlay/etc/network/interfaces
@@ -1,0 +1,6 @@
+# PRTOS Guest Partition network config
+# eth0 DHCP disabled — no physical NIC inside partition.
+# TAP interfaces (tap0-tap2) are configured by S99virtio_guest.
+
+auto lo
+iface lo inet loopback

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/guest_partition/src/virtio_frontend.c
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/guest_partition/src/virtio_frontend.c
@@ -175,6 +175,16 @@ static inline void write_all(int fd, const void *buf, size_t count)
 static void signal_handler(int sig)
 {
     (void)sig;
+    /* Clear frontend_ready flags IMMEDIATELY so the backend detects
+     * that the frontend has died.  This must happen before running = 0
+     * because SIGKILL might arrive before cleanup code executes. */
+    if (con_shm) { con_shm->frontend_ready = 0; __sync_synchronize(); }
+    if (blk_shm) { blk_shm->frontend_ready = 0; __sync_synchronize(); }
+    {
+        int i;
+        for (i = 0; i < VIRTIO_NUM_NET; i++)
+            if (net_shm[i]) { net_shm[i]->frontend_ready = 0; __sync_synchronize(); }
+    }
     running = 0;
 }
 

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/start_guest.S
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/start_guest.S
@@ -36,6 +36,18 @@
 #define BP_HEAP_END_PTR     0x224
 #define BP_RAMDISK_IMAGE    0x218
 #define BP_RAMDISK_SIZE     0x21c
+#define BP_ACPI_RSDP_ADDR   0x070   /* __u64 acpi_rsdp_addr (since boot protocol 2.14) */
+
+/* ACPI table region placed by QEMU at top of first 1GB RAM */
+#define ACPI_RSDP_ADDR      0x000F5290  /* RSDP in BIOS ROM area */
+#define ACPI_TABLES_START   0x3FFE0000  /* RSDT/FACP/DSDT/MADT/HPET/WAET */
+#define ACPI_TABLES_SIZE    0x00020000  /* 128KB covers all ACPI tables */
+
+/* e820 memory types */
+#define E820_TYPE_RAM       1
+#define E820_TYPE_RESERVED  2
+#define E820_TYPE_ACPI      3   /* ACPI reclaimable */
+#define E820_TYPE_NVS       4   /* ACPI Non-Volatile Storage */
 
 /* screen_info offsets (struct screen_info at boot_params offset 0) */
 #define SI_ORIG_VIDEO_MODE    0x06
@@ -100,15 +112,25 @@ _boot:
 	jnz	2b
 	movl	$CMDLINE_ADDR, (BP_CMDLINE_PTR)(%ebx)
 
-	/* --- Step 5: Set up e820 memory map --- */
-	/* 3 entries (shared memory accessed via /dev/mem, not in e820):
-	 *   0) 0x0000_0000  .. 0x0009_FFFF   (640KB)   usable (conventional)
-	 *   1) 0x000A_0000  .. 0x000F_FFFF   (384KB)   reserved (VGA/ROM)
-	 *   2) 0x0E00_0000 .. 0x15FF_FFFF   (128MB)   usable (partition RAM)
-	 * Note: Shared memory at 0x16000000+ is NOT in e820.
-	 *       Access shared memory via /dev/mem mmap instead.
+	/* --- Step 5: Set up ACPI RSDP address in boot_params ---
+	 * Linux 5.2+ (boot protocol 2.14+) uses this to find ACPI tables.
+	 * QEMU places RSDP at 0xF5290 in the BIOS ROM area (0xE0000-0xFFFFF).
+	 * EPT identity-maps the first 1GB, making both RSDP and ACPI tables
+	 * (at 0x3FFE0000+) accessible to the partition.
 	 */
-	movl	$3, (BP_E820_ENTRIES)(%ebx)
+	movl	$ACPI_RSDP_ADDR, (BP_ACPI_RSDP_ADDR)(%ebx)
+	movl	$0x00000000, (BP_ACPI_RSDP_ADDR + 4)(%ebx)
+
+	/* --- Step 6: Set up e820 memory map --- */
+	/* 4 entries:
+	 *   0) 0x0000_0000  .. 0x0009_FFFF   (640KB)   usable  (conventional)
+	 *   1) 0x000A_0000  .. 0x000F_FFFF   (384KB)   reserved (VGA/ROM/BIOS)
+	 *   2) 0x0E00_0000 .. 0x15FF_FFFF   (128MB)   usable  (partition RAM)
+	 *   3) 0x3FFE_0000 .. 0x3FFF_FFFF   (128KB)   ACPI    (RSDT/FACP/DSDT/MADT/HPET/WAET)
+	 * Note: RSDP at 0xF5290 is within entry 1 (reserved BIOS area).
+	 *       Shared memory at 0x16000000+ accessed via /dev/mem, not in e820.
+	 */
+	movl	$4, (BP_E820_ENTRIES)(%ebx)
 	movl	$(BP_E820_TABLE), %edi
 	addl	%ebx, %edi
 
@@ -117,29 +139,36 @@ _boot:
 	movl	$0x00000000, 4(%edi)
 	movl	$0x000A0000, 8(%edi)
 	movl	$0x00000000, 12(%edi)
-	movl	$1, 16(%edi)
+	movl	$E820_TYPE_RAM, 16(%edi)
 
-	/* Entry 1: Reserved VGA/ROM */
+	/* Entry 1: Reserved VGA/ROM/BIOS (includes RSDP at 0xF5290) */
 	movl	$0x000A0000, 20(%edi)
 	movl	$0x00000000, 24(%edi)
 	movl	$0x00060000, 28(%edi)
 	movl	$0x00000000, 32(%edi)
-	movl	$2, 36(%edi)
+	movl	$E820_TYPE_RESERVED, 36(%edi)
 
 	/* Entry 2: Partition RAM (128MB at 0xE000000) */
 	movl	$0x0E000000, 40(%edi)
 	movl	$0x00000000, 44(%edi)
 	movl	$0x08000000, 48(%edi)
 	movl	$0x00000000, 52(%edi)
-	movl	$1, 56(%edi)
+	movl	$E820_TYPE_RAM, 56(%edi)
 
-	/* --- Step 5b: Set up initrd (guest rootfs overlay CPIO) --- */
+	/* Entry 3: ACPI tables (QEMU places RSDT/FACP/DSDT/MADT/HPET/WAET here) */
+	movl	$ACPI_TABLES_START, 60(%edi)
+	movl	$0x00000000, 64(%edi)
+	movl	$ACPI_TABLES_SIZE, 68(%edi)
+	movl	$0x00000000, 72(%edi)
+	movl	$E820_TYPE_ACPI, 76(%edi)
+
+	/* --- Step 7: Set up initrd (guest rootfs overlay CPIO) --- */
 	movl	$_initrd_guest_start, (BP_RAMDISK_IMAGE)(%ebx)
 	movl	$_initrd_guest_end, %eax
 	subl	$_initrd_guest_start, %eax
 	movl	%eax, (BP_RAMDISK_SIZE)(%ebx)
 
-	/* --- Step 6: Calculate compressed kernel entry --- */
+	/* --- Step 8: Calculate compressed kernel entry --- */
 	movl	$_bzimage_guest_start, %eax
 	movzbl	HDR_SETUP_SECTS(%eax), %ecx
 	testl	%ecx, %ecx
@@ -149,7 +178,7 @@ _boot:
 	shll	$9, %ecx
 	addl	$_bzimage_guest_start, %ecx
 
-	/* --- Step 7: Jump to Linux startup_32 --- */
+	/* --- Step 9: Jump to Linux startup_32 --- */
 	movl	$BOOT_PARAMS_ADDR, %esi
 	jmp	*%ecx
 

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/start_guest.S
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/start_guest.S
@@ -38,10 +38,11 @@
 #define BP_RAMDISK_SIZE     0x21c
 #define BP_ACPI_RSDP_ADDR   0x070   /* __u64 acpi_rsdp_addr (since boot protocol 2.14) */
 
-/* ACPI table region placed by QEMU at top of first 1GB RAM */
-#define ACPI_RSDP_ADDR      0x000F5290  /* RSDP in BIOS ROM area */
-#define ACPI_TABLES_START   0x3FFE0000  /* RSDT/FACP/DSDT/MADT/HPET/WAET */
-#define ACPI_TABLES_SIZE    0x00020000  /* 128KB covers all ACPI tables */
+/* ACPI table region placed by QEMU at top of first 1GB RAM.
+ * Size must accommodate larger tables when PCI devices are present
+ * (DSDT grows with PCI bus/device definitions, SSDT added, etc.). */
+#define ACPI_TABLES_START   0x3FF80000  /* Conservative start for ACPI region */
+#define ACPI_TABLES_SIZE    0x00080000  /* 512KB covers ACPI tables with PCI */
 
 /* e820 memory types */
 #define E820_TYPE_RAM       1
@@ -112,22 +113,34 @@ _boot:
 	jnz	2b
 	movl	$CMDLINE_ADDR, (BP_CMDLINE_PTR)(%ebx)
 
-	/* --- Step 5: Set up ACPI RSDP address in boot_params ---
-	 * Linux 5.2+ (boot protocol 2.14+) uses this to find ACPI tables.
-	 * QEMU places RSDP at 0xF5290 in the BIOS ROM area (0xE0000-0xFFFFF).
-	 * EPT identity-maps the first 1GB, making both RSDP and ACPI tables
-	 * (at 0x3FFE0000+) accessible to the partition.
-	 */
-	movl	$ACPI_RSDP_ADDR, (BP_ACPI_RSDP_ADDR)(%ebx)
-	movl	$0x00000000, (BP_ACPI_RSDP_ADDR + 4)(%ebx)
+	/* --- Step 5: Scan for ACPI RSDP in BIOS ROM area (0xE0000-0xFFFFF) ---
+	 * QEMU places the RSDP at a dynamic offset that shifts depending on
+	 * the machine configuration (PCI devices change ACPI table sizes,
+	 * causing SeaBIOS to allocate the RSDP at a different address).
+	 * Scan for the "RSD PTR " signature (always 16-byte aligned). */
+	movl	$0xe0000, %esi
+.Lscan_rsdp_guest:
+	cmpl	$0x100000, %esi
+	jge	.Lno_rsdp_guest
+	cmpl	$0x20445352, (%esi)     /* "RSD " (little-endian) */
+	jne	.Lnext_rsdp_guest
+	cmpl	$0x20525450, 4(%esi)    /* "PTR " (little-endian) */
+	je	.Lfound_rsdp_guest
+.Lnext_rsdp_guest:
+	addl	$16, %esi
+	jmp	.Lscan_rsdp_guest
+.Lfound_rsdp_guest:
+	movl	%esi, (BP_ACPI_RSDP_ADDR)(%ebx)
+	movl	$0, (BP_ACPI_RSDP_ADDR + 4)(%ebx)
+.Lno_rsdp_guest:
 
 	/* --- Step 6: Set up e820 memory map --- */
 	/* 4 entries:
 	 *   0) 0x0000_0000  .. 0x0009_FFFF   (640KB)   usable  (conventional)
 	 *   1) 0x000A_0000  .. 0x000F_FFFF   (384KB)   reserved (VGA/ROM/BIOS)
 	 *   2) 0x0E00_0000 .. 0x15FF_FFFF   (128MB)   usable  (partition RAM)
-	 *   3) 0x3FFE_0000 .. 0x3FFF_FFFF   (128KB)   ACPI    (RSDT/FACP/DSDT/MADT/HPET/WAET)
-	 * Note: RSDP at 0xF5290 is within entry 1 (reserved BIOS area).
+	 *   3) 0x3FF8_0000 .. 0x3FFF_FFFF   (512KB)   ACPI    (ACPI tables, sized for PCI configs)
+	 * Note: RSDP is found dynamically in BIOS ROM area by Step 5.
 	 *       Shared memory at 0x16000000+ accessed via /dev/mem, not in e820.
 	 */
 	movl	$4, (BP_E820_ENTRIES)(%ebx)
@@ -156,7 +169,7 @@ _boot:
 	movl	$E820_TYPE_RAM, 56(%edi)
 
 	/* Entry 3: ACPI tables (QEMU places RSDT/FACP/DSDT/MADT/HPET/WAET here) */
-	movl	$ACPI_TABLES_START, 60(%edi)
+	movl	$ACPI_TABLES_START, 60(%edi)    /* 0x3FF80000 */
 	movl	$0x00000000, 64(%edi)
 	movl	$ACPI_TABLES_SIZE, 68(%edi)
 	movl	$0x00000000, 72(%edi)

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/start_system.S
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/start_system.S
@@ -39,6 +39,18 @@
 #define BP_HEAP_END_PTR     0x224
 #define BP_RAMDISK_IMAGE    0x218
 #define BP_RAMDISK_SIZE     0x21c
+#define BP_ACPI_RSDP_ADDR   0x070   /* __u64 acpi_rsdp_addr (since boot protocol 2.14) */
+
+/* ACPI table region placed by QEMU at top of first 1GB RAM */
+#define ACPI_RSDP_ADDR      0x000F5290  /* RSDP in BIOS ROM area */
+#define ACPI_TABLES_START   0x3FFE0000  /* RSDT/FACP/DSDT/MADT/HPET/WAET */
+#define ACPI_TABLES_SIZE    0x00020000  /* 128KB covers all ACPI tables */
+
+/* e820 memory types */
+#define E820_TYPE_RAM       1
+#define E820_TYPE_RESERVED  2
+#define E820_TYPE_ACPI      3   /* ACPI reclaimable */
+#define E820_TYPE_NVS       4   /* ACPI Non-Volatile Storage */
 
 	.code32
 	.section .text
@@ -84,15 +96,25 @@ _boot:
 	jnz	2b
 	movl	$CMDLINE_ADDR, (BP_CMDLINE_PTR)(%ebx)
 
-	/* --- Step 5: Set up e820 memory map --- */
-	/* 3 entries (shared memory accessed via /dev/mem, not in e820):
-	 *   0) 0x0000_0000 .. 0x0009_FFFF  (640KB)   usable (conventional)
-	 *   1) 0x000A_0000 .. 0x000F_FFFF  (384KB)   reserved (VGA/ROM)
-	 *   2) 0x0600_0000 .. 0x0DFF_FFFF  (128MB)   usable (partition RAM)
-	 * Note: Shared memory at 0x16000000+ is NOT in e820.
-	 *       Access shared memory via /dev/mem mmap instead.
+	/* --- Step 5: Set up ACPI RSDP address in boot_params ---
+	 * Linux 5.2+ (boot protocol 2.14+) uses this to find ACPI tables.
+	 * QEMU places RSDP at 0xF5290 in the BIOS ROM area (0xE0000-0xFFFFF).
+	 * EPT identity-maps the first 1GB, making both RSDP and ACPI tables
+	 * (at 0x3FFE0000+) accessible to the partition.
 	 */
-	movl	$3, (BP_E820_ENTRIES)(%ebx)
+	movl	$ACPI_RSDP_ADDR, (BP_ACPI_RSDP_ADDR)(%ebx)
+	movl	$0x00000000, (BP_ACPI_RSDP_ADDR + 4)(%ebx)
+
+	/* --- Step 6: Set up e820 memory map --- */
+	/* 4 entries:
+	 *   0) 0x0000_0000 .. 0x0009_FFFF  (640KB)   usable  (conventional)
+	 *   1) 0x000A_0000 .. 0x000F_FFFF  (384KB)   reserved (VGA/ROM/BIOS)
+	 *   2) 0x0600_0000 .. 0x0DFF_FFFF  (128MB)   usable  (partition RAM)
+	 *   3) 0x3FFE_0000 .. 0x3FFF_FFFF  (128KB)   ACPI    (RSDT/FACP/DSDT/MADT/HPET/WAET)
+	 * Note: RSDP at 0xF5290 is within entry 1 (reserved BIOS area).
+	 *       Shared memory at 0x16000000+ accessed via /dev/mem, not in e820.
+	 */
+	movl	$4, (BP_E820_ENTRIES)(%ebx)
 	movl	$(BP_E820_TABLE), %edi
 	addl	%ebx, %edi
 
@@ -101,23 +123,30 @@ _boot:
 	movl	$0x00000000, 4(%edi)
 	movl	$0x000A0000, 8(%edi)
 	movl	$0x00000000, 12(%edi)
-	movl	$1, 16(%edi)
+	movl	$E820_TYPE_RAM, 16(%edi)
 
-	/* Entry 1: Reserved VGA/ROM */
+	/* Entry 1: Reserved VGA/ROM/BIOS (includes RSDP at 0xF5290) */
 	movl	$0x000A0000, 20(%edi)
 	movl	$0x00000000, 24(%edi)
 	movl	$0x00060000, 28(%edi)
 	movl	$0x00000000, 32(%edi)
-	movl	$2, 36(%edi)
+	movl	$E820_TYPE_RESERVED, 36(%edi)
 
 	/* Entry 2: Partition RAM (128MB at 0x6000000) */
 	movl	$0x06000000, 40(%edi)
 	movl	$0x00000000, 44(%edi)
 	movl	$0x08000000, 48(%edi)
 	movl	$0x00000000, 52(%edi)
-	movl	$1, 56(%edi)
+	movl	$E820_TYPE_RAM, 56(%edi)
 
-	/* --- Step 5b: Set up initrd (rootfs overlay CPIO) --- */
+	/* Entry 3: ACPI tables (QEMU places RSDT/FACP/DSDT/MADT/HPET/WAET here) */
+	movl	$ACPI_TABLES_START, 60(%edi)
+	movl	$0x00000000, 64(%edi)
+	movl	$ACPI_TABLES_SIZE, 68(%edi)
+	movl	$0x00000000, 72(%edi)
+	movl	$E820_TYPE_ACPI, 76(%edi)
+
+	/* --- Step 7: Set up initrd (rootfs overlay CPIO) --- */
 	/* Linux boot protocol: ramdisk_image = physical address of initrd,
 	 * ramdisk_size = byte length. Linux will unpack this CPIO on top of
 	 * the built-in initramfs, overlaying /usr/bin/prtos_manager etc.
@@ -127,7 +156,7 @@ _boot:
 	subl	$_initrd_sys_start, %eax
 	movl	%eax, (BP_RAMDISK_SIZE)(%ebx)
 
-	/* --- Step 6: Calculate compressed kernel entry --- */
+	/* --- Step 8: Calculate compressed kernel entry --- */
 	movl	$_bzimage_sys_start, %eax
 	movzbl	HDR_SETUP_SECTS(%eax), %ecx
 	testl	%ecx, %ecx
@@ -137,7 +166,7 @@ _boot:
 	shll	$9, %ecx
 	addl	$_bzimage_sys_start, %ecx
 
-	/* --- Step 7: Jump to Linux startup_32 --- */
+	/* --- Step 9: Jump to Linux startup_32 --- */
 	movl	$BOOT_PARAMS_ADDR, %esi
 	jmp	*%ecx
 

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/start_system.S
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/start_system.S
@@ -41,10 +41,11 @@
 #define BP_RAMDISK_SIZE     0x21c
 #define BP_ACPI_RSDP_ADDR   0x070   /* __u64 acpi_rsdp_addr (since boot protocol 2.14) */
 
-/* ACPI table region placed by QEMU at top of first 1GB RAM */
-#define ACPI_RSDP_ADDR      0x000F5290  /* RSDP in BIOS ROM area */
-#define ACPI_TABLES_START   0x3FFE0000  /* RSDT/FACP/DSDT/MADT/HPET/WAET */
-#define ACPI_TABLES_SIZE    0x00020000  /* 128KB covers all ACPI tables */
+/* ACPI table region placed by QEMU at top of first 1GB RAM.
+ * Size must accommodate larger tables when PCI devices are present
+ * (DSDT grows with PCI bus/device definitions, SSDT added, etc.). */
+#define ACPI_TABLES_START   0x3FF80000  /* Conservative start for ACPI region */
+#define ACPI_TABLES_SIZE    0x00080000  /* 512KB covers ACPI tables with PCI */
 
 /* e820 memory types */
 #define E820_TYPE_RAM       1
@@ -96,22 +97,34 @@ _boot:
 	jnz	2b
 	movl	$CMDLINE_ADDR, (BP_CMDLINE_PTR)(%ebx)
 
-	/* --- Step 5: Set up ACPI RSDP address in boot_params ---
-	 * Linux 5.2+ (boot protocol 2.14+) uses this to find ACPI tables.
-	 * QEMU places RSDP at 0xF5290 in the BIOS ROM area (0xE0000-0xFFFFF).
-	 * EPT identity-maps the first 1GB, making both RSDP and ACPI tables
-	 * (at 0x3FFE0000+) accessible to the partition.
-	 */
-	movl	$ACPI_RSDP_ADDR, (BP_ACPI_RSDP_ADDR)(%ebx)
-	movl	$0x00000000, (BP_ACPI_RSDP_ADDR + 4)(%ebx)
+	/* --- Step 5: Scan for ACPI RSDP in BIOS ROM area (0xE0000-0xFFFFF) ---
+	 * QEMU places the RSDP at a dynamic offset that shifts depending on
+	 * the machine configuration (PCI devices change ACPI table sizes,
+	 * causing SeaBIOS to allocate the RSDP at a different address).
+	 * Scan for the "RSD PTR " signature (always 16-byte aligned). */
+	movl	$0xe0000, %esi
+.Lscan_rsdp_sys:
+	cmpl	$0x100000, %esi
+	jge	.Lno_rsdp_sys
+	cmpl	$0x20445352, (%esi)     /* "RSD " (little-endian) */
+	jne	.Lnext_rsdp_sys
+	cmpl	$0x20525450, 4(%esi)    /* "PTR " (little-endian) */
+	je	.Lfound_rsdp_sys
+.Lnext_rsdp_sys:
+	addl	$16, %esi
+	jmp	.Lscan_rsdp_sys
+.Lfound_rsdp_sys:
+	movl	%esi, (BP_ACPI_RSDP_ADDR)(%ebx)
+	movl	$0, (BP_ACPI_RSDP_ADDR + 4)(%ebx)
+.Lno_rsdp_sys:
 
 	/* --- Step 6: Set up e820 memory map --- */
 	/* 4 entries:
 	 *   0) 0x0000_0000 .. 0x0009_FFFF  (640KB)   usable  (conventional)
 	 *   1) 0x000A_0000 .. 0x000F_FFFF  (384KB)   reserved (VGA/ROM/BIOS)
 	 *   2) 0x0600_0000 .. 0x0DFF_FFFF  (128MB)   usable  (partition RAM)
-	 *   3) 0x3FFE_0000 .. 0x3FFF_FFFF  (128KB)   ACPI    (RSDT/FACP/DSDT/MADT/HPET/WAET)
-	 * Note: RSDP at 0xF5290 is within entry 1 (reserved BIOS area).
+	 *   3) 0x3FF8_0000 .. 0x3FFF_FFFF  (512KB)   ACPI    (ACPI tables, sized for PCI configs)
+	 * Note: RSDP is found dynamically in BIOS ROM area by Step 5.
 	 *       Shared memory at 0x16000000+ accessed via /dev/mem, not in e820.
 	 */
 	movl	$4, (BP_E820_ENTRIES)(%ebx)
@@ -140,7 +153,7 @@ _boot:
 	movl	$E820_TYPE_RAM, 56(%edi)
 
 	/* Entry 3: ACPI tables (QEMU places RSDT/FACP/DSDT/MADT/HPET/WAET here) */
-	movl	$ACPI_TABLES_START, 60(%edi)
+	movl	$ACPI_TABLES_START, 60(%edi)    /* 0x3FF80000 */
 	movl	$0x00000000, 64(%edi)
 	movl	$ACPI_TABLES_SIZE, 68(%edi)
 	movl	$0x00000000, 72(%edi)

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/include/virtio_be.h
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/include/virtio_be.h
@@ -241,6 +241,7 @@ struct virtio_net_instance {
 void virtio_console_init(struct virtio_console_shm *con);
 void virtio_console_process(struct virtio_console_shm *con);
 void virtio_console_cleanup(void);
+void virtio_console_notify_guest_halt(void);
 
 /* virtio_net.c */
 int  virtio_net_init(struct virtio_net_instance *inst);

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/rootfs_overlay/etc/network/interfaces
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/rootfs_overlay/etc/network/interfaces
@@ -1,0 +1,6 @@
+# PRTOS System Partition network config
+# eth0 DHCP disabled — no physical NIC inside partition.
+# TAP interfaces (tap0-tap2) are configured by S99virtio_backend.
+
+auto lo
+iface lo inet loopback

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/src/main.c
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/src/main.c
@@ -249,6 +249,41 @@ int main(int argc, char *argv[])
     /* Main event loop */
     while (running) {
         int processed = 0;
+        static int guest_halt_detected = 0;
+        static int con_was_ready = 0;    /* tracks frontend_ready 1→0 transition */
+        /* Check guest partition status every ~1000 iterations (1 second).
+         * When halt is detected, disconnect TCP clients and stop IPVIs. */
+        static int halt_check_counter = 0;
+
+        /* Track frontend_ready state for transition detection */
+        if (!guest_halt_detected && con_shm->frontend_ready == 1)
+            con_was_ready = 1;
+
+        if (!guest_halt_detected && ++halt_check_counter >= 1000) {
+            halt_check_counter = 0;
+            /* Method 1: Check PRTOS hypervisor partition status */
+            if (hv_available) {
+                prtos_part_status_t guest_status;
+                if (prtos_hv_get_partition_status(GUEST_PARTITION_ID, &guest_status) >= 0) {
+                    if (guest_status.state == PRTOS_STATUS_HALTED) {
+                        printf("\n[Backend] Guest Partition %d has HALTED (resets: %u)\n",
+                               GUEST_PARTITION_ID, guest_status.reset_counter);
+                        guest_halt_detected = 1;
+                        virtio_console_notify_guest_halt();
+                    }
+                }
+            }
+            /* Method 2: Detect frontend death via frontend_ready flag.
+             * When the guest shuts down, init sends SIGTERM to the frontend.
+             * The frontend's signal handler clears frontend_ready = 0.
+             * This fires when the flag transitions from 1 to 0, indicating
+             * the frontend process exited. */
+            if (!guest_halt_detected && con_was_ready && con_shm->frontend_ready == 0) {
+                printf("\n[Backend] Guest frontend disconnected (frontend_ready: 1->0)\n");
+                guest_halt_detected = 1;
+                virtio_console_notify_guest_halt();
+            }
+        }
 
         /* Process each device's queues */
         for (i = 0; i < VIRTIO_NUM_NET; i++)
@@ -279,8 +314,8 @@ int main(int argc, char *argv[])
             }
         }
 
-        /* Signal Guest via IPVI completion doorbell */
-        if (processed && hv_available) {
+        /* Signal Guest via IPVI completion doorbell (skip if guest halted) */
+        if (processed && hv_available && !guest_halt_detected) {
             prtos_hv_raise_partition_ipvi(GUEST_PARTITION_ID, IPVI_SYS_TO_GUEST);
         }
 

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/src/virtio_console.c
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/src/virtio_console.c
@@ -53,6 +53,32 @@ static int client_fd = -1;
  */
 static int iac_state = 0;
 
+/*
+ * Deferred newline injection state.
+ *
+ * When a TCP client connects, getty has likely already printed its
+ * initial login prompt (consumed by stdout only).  We inject '\n'
+ * into the Guest RX buffer so getty re-displays "login:" for the
+ * newly connected client.
+ *
+ * Injection is deferred because the frontend's PTY bridge may not
+ * be actively draining RX yet (or getty's tcsetattr may flush it).
+ * We retry multiple times until getty responds (tx_tail advances).
+ *
+ * Each poll iteration ≈ 1ms (usleep(1000) in main loop).
+ */
+#define INJECT_INITIAL_DELAY_MS  300    /* Wait before first injection */
+#define INJECT_RETRY_INTERVAL_MS 500    /* Interval between retries */
+#define INJECT_MAX_RETRIES       5      /* Max injection attempts */
+
+static int inject_counter = -1;        /* Countdown to next injection (ms) */
+static int inject_retries = 0;         /* Remaining retry attempts */
+static uint32_t inject_tx_baseline = 0; /* tx_tail snapshot for response check */
+static int inject_baseline_set = 0;    /* Whether baseline has been captured */
+
+/* Guest halt state — set by virtio_console_notify_guest_halt() */
+static volatile int guest_halted = 0;
+
 void virtio_console_init(struct virtio_console_shm *con)
 {
     struct sockaddr_in addr;
@@ -68,6 +94,7 @@ void virtio_console_init(struct virtio_console_shm *con)
     con->buf_size = VIRTIO_CONSOLE_BUF_SIZE;
     con->device_status = VIRTIO_STATUS_ACK;
     con->backend_ready = 1;
+    guest_halted = 0;
     __sync_synchronize();
 
     /* Create TCP listening socket for Guest console access */
@@ -112,12 +139,65 @@ void virtio_console_init(struct virtio_console_shm *con)
            con->buf_size, CONSOLE_TCP_PORT);
 }
 
+/*
+ * Notify the console backend that the Guest partition has halted.
+ * Called from the main loop when guest halt is detected.
+ * Disconnects the TCP client so the telnet user gets back to shell.
+ */
+void virtio_console_notify_guest_halt(void)
+{
+    guest_halted = 1;
+    if (client_fd >= 0) {
+        /* Send a notification message to the telnet client */
+        static const char msg[] =
+            "\r\n\r\n[PRTOS] Guest partition has halted.\r\n"
+            "[PRTOS] Connection closed.\r\n";
+        (void)write(client_fd, msg, sizeof(msg) - 1);
+        close(client_fd);
+        client_fd = -1;
+        iac_state = 0;
+        inject_retries = 0;
+        inject_counter = -1;
+        printf("[Backend] Console TCP client disconnected (guest halted)\n");
+    }
+}
+
+static void close_client(void)
+{
+    if (client_fd >= 0) {
+        close(client_fd);
+        client_fd = -1;
+    }
+    iac_state = 0;
+    inject_retries = 0;
+    inject_counter = -1;
+    inject_baseline_set = 0;
+}
+
 void virtio_console_process(struct virtio_console_shm *con)
 {
     uint32_t head, tail;
 
     if (!con)
         return;
+
+    /* Don't accept new connections if guest is halted */
+    if (guest_halted) {
+        /* Still drain TX buffer to stdout (show final shutdown messages) */
+        __sync_synchronize();
+        head = con->tx_head;
+        tail = con->tx_tail;
+        while (tail != head) {
+            putchar(con->tx_buf[tail % con->buf_size]);
+            tail = (tail + 1) % con->buf_size;
+        }
+        if (con->tx_tail != tail) {
+            con->tx_tail = tail;
+            __sync_synchronize();
+            fflush(stdout);
+        }
+        return;
+    }
 
     /* Accept new TCP connection (non-blocking) */
     if (listen_fd >= 0 && client_fd < 0) {
@@ -129,6 +209,20 @@ void virtio_console_process(struct virtio_console_shm *con)
             /* Disable Nagle for interactive terminal */
             int opt = 1;
             setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));
+
+            /* Enable TCP keepalive so dead connections are detected.
+             * - Idle time before first probe: 10s
+             * - Interval between probes: 5s
+             * - Max failed probes before disconnect: 3
+             * Total dead-connection detection: ~25s */
+            opt = 1;
+            setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &opt, sizeof(opt));
+            opt = 10;
+            setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &opt, sizeof(opt));
+            opt = 5;
+            setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &opt, sizeof(opt));
+            opt = 3;
+            setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &opt, sizeof(opt));
 
             /* Send telnet negotiation: character-at-a-time mode.
              * WILL ECHO: server handles echo (prevents double-echo)
@@ -143,24 +237,19 @@ void virtio_console_process(struct virtio_console_shm *con)
             (void)write(fd, telnet_init, sizeof(telnet_init));
 
             client_fd = fd;
-            iac_state = 0;  /* Reset IAC parser for new client */
+            iac_state = 0;
             printf("[Backend] Console TCP client connected\n");
 
-            /* Inject newline to make getty re-display login prompt.
+            /* Schedule deferred newline injection.
              * Getty has already printed the initial prompt before the
-             * TCP client connected, so it was consumed (sent to stdout
-             * only).  A newline causes getty to see an empty username
-             * and re-display "login:", which goes to the TCP client. */
-            __sync_synchronize();
-            {
-                uint32_t rx_h = con->rx_head;
-                uint32_t rx_next = (rx_h + 1) % con->buf_size;
-                if (rx_next != con->rx_tail) {
-                    con->rx_buf[rx_h] = '\n';
-                    con->rx_head = rx_next;
-                    __sync_synchronize();
-                }
-            }
+             * TCP client connected (consumed by stdout only).  A '\n'
+             * causes getty to re-display "login:" for the TCP client.
+             *
+             * We defer injection to allow the frontend PTY bridge to
+             * settle after potential getty respawn (tcsetattr may flush). */
+            inject_counter = INJECT_INITIAL_DELAY_MS;
+            inject_retries = INJECT_MAX_RETRIES;
+            inject_baseline_set = 0;
         }
     }
 
@@ -175,8 +264,8 @@ void virtio_console_process(struct virtio_console_shm *con)
         if (client_fd >= 0) {
             ssize_t w = write(client_fd, &c, 1);
             if (w < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-                close(client_fd);
-                client_fd = -1;
+                printf("[Backend] Console TCP client write error\n");
+                close_client();
             }
         }
         tail = (tail + 1) % con->buf_size;
@@ -186,6 +275,40 @@ void virtio_console_process(struct virtio_console_shm *con)
         con->tx_tail = tail;
         __sync_synchronize();
         fflush(stdout);
+    }
+
+    /* Deferred newline injection with retry.
+     * Placed AFTER the TX read section so that the baseline tx_tail
+     * reflects the state after draining any stale data. */
+    if (inject_retries > 0 && client_fd >= 0) {
+        if (!inject_baseline_set) {
+            /* Capture tx_tail baseline AFTER stale TX data is drained */
+            inject_tx_baseline = con->tx_tail;
+            inject_baseline_set = 1;
+        }
+        /* Check if getty already responded (tx_tail advanced) */
+        __sync_synchronize();
+        if (con->tx_tail != inject_tx_baseline) {
+            /* Getty produced output — login prompt sent, stop injecting */
+            inject_retries = 0;
+            inject_counter = -1;
+        } else if (inject_counter > 0) {
+            inject_counter--;
+        } else {
+            /* Time to inject '\n' */
+            uint32_t rx_h = con->rx_head;
+            uint32_t rx_next = (rx_h + 1) % con->buf_size;
+            if (rx_next != con->rx_tail) {
+                con->rx_buf[rx_h] = '\n';
+                con->rx_head = rx_next;
+                __sync_synchronize();
+            }
+            inject_retries--;
+            if (inject_retries > 0)
+                inject_counter = INJECT_RETRY_INTERVAL_MS;
+            else
+                inject_counter = -1;
+        }
     }
 
     /* Read from TCP client and write to Guest's RX buffer */
@@ -210,24 +333,21 @@ void virtio_console_process(struct virtio_console_shm *con)
                  * data (e.g. NAWS window-size bytes) leak into the
                  * guest PTY, potentially killing getty via SIGINT. */
                 if (iac_state == 3) {
-                    /* Inside SB subnegotiation: discard data until IAC */
                     if (ch == TELNET_IAC)
                         iac_state = 4;
                     continue;
                 }
                 if (iac_state == 4) {
-                    /* SB subneg saw IAC: expect SE(240) to end */
                     if (ch == 240) {
                         iac_state = 0;  /* SE: subneg complete */
                     } else if (ch == TELNET_IAC) {
-                        iac_state = 4;  /* IAC IAC inside SB: escaped 0xFF, stay */
+                        iac_state = 4;  /* escaped 0xFF inside SB */
                     } else {
-                        iac_state = 3;  /* Not SE: back to scanning */
+                        iac_state = 3;  /* back to scanning */
                     }
                     continue;
                 }
                 if (iac_state == 1) {
-                    /* After IAC: expect command byte */
                     if (ch == TELNET_IAC) {
                         /* IAC IAC = escaped literal 0xFF */
                         iac_state = 0;
@@ -237,22 +357,16 @@ void virtio_console_process(struct virtio_console_shm *con)
                         con->rx_buf[head] = (char)0xFF;
                         head = next_head;
                     } else if (ch >= TELNET_WILL && ch <= TELNET_DONT) {
-                        /* WILL(251)/WONT(252)/DO(253)/DONT(254):
-                         * 3-byte sequence, need option byte next */
                         iac_state = 2;
                     } else if (ch == 250) {
-                        /* SB(250): subnegotiation start, discard until IAC SE */
-                        iac_state = 3;
+                        iac_state = 3;  /* SB subnegotiation */
                     } else {
-                        /* Other IAC commands (NOP, BRK, IP, etc.):
-                         * 2-byte sequence, done */
-                        iac_state = 0;
+                        iac_state = 0;  /* 2-byte command done */
                     }
                     continue;
                 }
                 if (iac_state == 2) {
-                    /* After IAC + cmd: this is the option byte, skip it */
-                    iac_state = 0;
+                    iac_state = 0;      /* option byte consumed */
                     continue;
                 }
                 if (ch == TELNET_IAC) {
@@ -271,23 +385,17 @@ void virtio_console_process(struct virtio_console_shm *con)
             __sync_synchronize();
         } else if (n == 0) {
             printf("[Backend] Console TCP client disconnected\n");
-            close(client_fd);
-            client_fd = -1;
-            iac_state = 0;  /* Reset IAC state for next client */
+            close_client();
         } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
-            close(client_fd);
-            client_fd = -1;
-            iac_state = 0;
+            printf("[Backend] Console TCP client error: %s\n", strerror(errno));
+            close_client();
         }
     }
 }
 
 void virtio_console_cleanup(void)
 {
-    if (client_fd >= 0) {
-        close(client_fd);
-        client_fd = -1;
-    }
+    close_client();
     if (listen_fd >= 0) {
         close(listen_fd);
         listen_fd = -1;

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/test_com2.py
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/test_com2.py
@@ -57,6 +57,7 @@ cmd = (f"{sg_pre}qemu-system-x86_64 "
        "-cdrom resident_sw.iso "
        "-serial mon:stdio "
        f"-serial telnet::{COM2_PORT},server,nowait "
+       "-nic none "
        f"-boot d{sg_post}")
 
 print("[TEST] Starting QEMU with COM2 on port %d..." % COM2_PORT)

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/test_console.py
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/test_console.py
@@ -60,9 +60,8 @@ cmd = (f"{sg_pre}qemu-system-x86_64 "
        "-nographic -no-reboot "
        "-cdrom resident_sw.iso "
        "-serial mon:stdio "
+       "-nic none "
        f"-boot d{sg_post}")
-
-print("=== Starting QEMU for Console Test ===")
 child = pexpect.spawn("/bin/bash", ["-c", cmd], encoding='utf-8',
                       timeout=TIMEOUT, codec_errors='replace')
 child.logfile = sys.stdout

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/test_login.py
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/test_login.py
@@ -43,6 +43,7 @@ cmd = ("sg kvm -c 'qemu-system-x86_64 "
        "-cdrom resident_sw.iso "
        "-serial mon:stdio "
        "-serial null "
+       "-nic none "
        "-boot d'")
 
 print("=== Starting QEMU ===")

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/test_smp.py
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/test_smp.py
@@ -61,6 +61,7 @@ cmd = (f"{sg_pre}qemu-system-x86_64 "
        "-nographic -no-reboot "
        "-cdrom resident_sw.iso "
        "-serial mon:stdio "
+       "-nic none "
        f"-boot d{sg_post}")
 
 print("=== Starting QEMU for SMP test ===")

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/test_tcp_bridge.py
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/test_tcp_bridge.py
@@ -59,6 +59,7 @@ cmd = (f"{sg_pre}qemu-system-x86_64 "
        "-m 1024 -smp 4 -nographic -no-reboot "
        "-cdrom resident_sw.iso "
        "-serial mon:stdio "
+       "-nic none "
        f"-boot d{sg_post}")
 
 print("=== Starting QEMU for TCP Bridge Test ===")


### PR DESCRIPTION
This patch enables ACPI discovery and management for both system and guest partitions, allowing modern Linux kernels (5.2+) to properly detect hardware configuration and use advanced power management features.

Key changes:
1. Set boot_params.acpi_rsdp_addr to 0x000F5290 for Linux 5.2+ direct ACPI table discovery via the RSDP pointer
2. Add ACPI reclaimable memory region (0x3FFE0000-0x3FFFFFFF, 128KB) to e820 map to protect ACPI tables (RSDT/FACP/DSDT/MADT/HPET/WAET) from being used as normal RAM
3. Enable ACPI PM I/O ports (0x600-0x63F) in system partition for PM Timer access
4. Replace magic numbers with named E820_TYPE_* constants for better readability
5. Add comprehensive ACPI hardware documentation in resident_sw.xml describing table locations, EPT mappings, and QEMU-provided hardware layout
6. Maintain 'nohpet' kernel parameter due to nested virtualization timer interrupt delivery limitations

Technical details:
- RSDP located in BIOS ROM area (0x000F5290) as provided by QEMU
- ACPI tables placed at 0x3FFE0000-0x3FFFFFFF via EPT identity mapping
- Both partitions share the same ACPI tables but have separate RAM regions
- Linux uses PM Timer at I/O port 0x608 as clocksource when HPET is unavailable
- e820 type 3 (ACPI reclaimable) allows kernel to reclaim memory after extracting ACPI tables during boot

Impact:
- Enables SMP CPU topology detection via MADT
- Provides proper HPET/PM Timer for timekeeping
- Allows ACPI-based power management in guest partitions
- Maintains backward compatibility with existing shared memory and virtio devices