### PR TITLE
[qemu][riscv64][aarch64][amd64] Fixed incorrect BusyBox getty argument ordering to ensure proper console startup

### DIFF
--- a/user/bail/examples/virtio_linux_demo_2p_aarch64/guest_partition/rootfs_overlay/etc/init.d/S99virtio_guest
+++ b/user/bail/examples/virtio_linux_demo_2p_aarch64/guest_partition/rootfs_overlay/etc/init.d/S99virtio_guest
@@ -4,6 +4,17 @@
 # Starts Virtio Frontend daemon and spawns getty on /dev/hvc0 (PTY via shared memory).
 # Guest console accessible from System partition: telnet 127.0.0.1 4321
 #
+# Getty is respawned automatically when it exits (e.g., after user logout),
+# so subsequent telnet connections always find a live login prompt.
+#
+
+# Respawn getty in an infinite loop.
+respawn_getty() {
+    while true; do
+        /sbin/getty "$@"
+        sleep 1
+    done
+}
 
 case "$1" in
     start)
@@ -39,7 +50,7 @@ case "$1" in
                 tries=$((tries - 1))
             done
             if [ -e /dev/hvc0 ]; then
-                /sbin/getty -L hvc0 115200 vt100 &
+                respawn_getty -L hvc0 115200 vt100 &
             fi
         ) &
         ;;

--- a/user/bail/examples/virtio_linux_demo_2p_aarch64/system_partition/src/virtio_console.c
+++ b/user/bail/examples/virtio_linux_demo_2p_aarch64/system_partition/src/virtio_console.c
@@ -1,7 +1,7 @@
 /*
  * virtio_console.c - Virtio Console backend for PRTOS System Partition.
  *
- * Uses the Virtio_Con shared memory region (256KB).
+ * Uses the Virtio_Con shared memory region at GPA 0x16500000 (256KB).
  *
  * Data flow (bidirectional):
  *   Guest writes to /dev/hvc0 -> tx_buf in shared memory -> Backend reads
@@ -39,6 +39,19 @@
 
 static int listen_fd = -1;
 static int client_fd = -1;
+
+/*
+ * Telnet IAC state machine - persists across read() calls to handle
+ * IAC sequences split across TCP segment boundaries.
+ *
+ * States:
+ *   0 = normal data
+ *   1 = received IAC (0xFF), waiting for command byte
+ *   2 = received IAC + WILL/WONT/DO/DONT, waiting for option byte
+ *   3 = inside IAC SB subnegotiation, scanning for IAC
+ *   4 = inside IAC SB subnegotiation, received IAC, waiting for SE
+ */
+static int iac_state = 0;
 
 void virtio_console_init(struct virtio_console_shm *con)
 {
@@ -130,6 +143,24 @@ void virtio_console_process(struct virtio_console_shm *con)
             (void)write(fd, telnet_init, sizeof(telnet_init));
 
             client_fd = fd;
+            iac_state = 0;  /* Reset IAC parser for new client */
+            printf("[Backend] Console TCP client connected\n");
+
+            /* Inject newline to make getty re-display login prompt.
+             * Getty has already printed the initial prompt before the
+             * TCP client connected, so it was consumed (sent to stdout
+             * only).  A newline causes getty to see an empty username
+             * and re-display "login:", which goes to the TCP client. */
+            __sync_synchronize();
+            {
+                uint32_t rx_h = con->rx_head;
+                uint32_t rx_next = (rx_h + 1) % con->buf_size;
+                if (rx_next != con->rx_tail) {
+                    con->rx_buf[rx_h] = '\n';
+                    con->rx_head = rx_next;
+                    __sync_synchronize();
+                }
+            }
         }
     }
 
@@ -166,11 +197,70 @@ void virtio_console_process(struct virtio_console_shm *con)
             head = con->rx_head;
             for (ssize_t i = 0; i < n; i++) {
                 unsigned char ch = (unsigned char)buf[i];
-                /* Filter telnet IAC sequences (IAC + cmd + option = 3 bytes) */
-                if (ch == TELNET_IAC) {
-                    i += 2;  /* skip command and option bytes */
+
+                /* Telnet IAC state machine — handles sequences split
+                 * across read() boundaries.  States:
+                 *   0: normal data
+                 *   1: after IAC, waiting for command byte
+                 *   2: after IAC WILL/WONT/DO/DONT, waiting for option
+                 *   3: inside SB subnegotiation, scanning for IAC
+                 *   4: inside SB subneg, got IAC, waiting for SE
+                 *
+                 * Without this, partial IAC sequences or SB subneg
+                 * data (e.g. NAWS window-size bytes) leak into the
+                 * guest PTY, potentially killing getty via SIGINT. */
+                if (iac_state == 3) {
+                    /* Inside SB subnegotiation: discard data until IAC */
+                    if (ch == TELNET_IAC)
+                        iac_state = 4;
                     continue;
                 }
+                if (iac_state == 4) {
+                    /* SB subneg saw IAC: expect SE(240) to end */
+                    if (ch == 240) {
+                        iac_state = 0;  /* SE: subneg complete */
+                    } else if (ch == TELNET_IAC) {
+                        iac_state = 4;  /* IAC IAC inside SB: escaped 0xFF, stay */
+                    } else {
+                        iac_state = 3;  /* Not SE: back to scanning */
+                    }
+                    continue;
+                }
+                if (iac_state == 1) {
+                    /* After IAC: expect command byte */
+                    if (ch == TELNET_IAC) {
+                        /* IAC IAC = escaped literal 0xFF */
+                        iac_state = 0;
+                        uint32_t next_head = (head + 1) % con->buf_size;
+                        if (next_head == con->rx_tail)
+                            break;
+                        con->rx_buf[head] = (char)0xFF;
+                        head = next_head;
+                    } else if (ch >= TELNET_WILL && ch <= TELNET_DONT) {
+                        /* WILL(251)/WONT(252)/DO(253)/DONT(254):
+                         * 3-byte sequence, need option byte next */
+                        iac_state = 2;
+                    } else if (ch == 250) {
+                        /* SB(250): subnegotiation start, discard until IAC SE */
+                        iac_state = 3;
+                    } else {
+                        /* Other IAC commands (NOP, BRK, IP, etc.):
+                         * 2-byte sequence, done */
+                        iac_state = 0;
+                    }
+                    continue;
+                }
+                if (iac_state == 2) {
+                    /* After IAC + cmd: this is the option byte, skip it */
+                    iac_state = 0;
+                    continue;
+                }
+                if (ch == TELNET_IAC) {
+                    iac_state = 1;
+                    continue;
+                }
+
+                /* Normal data byte */
                 uint32_t next_head = (head + 1) % con->buf_size;
                 if (next_head == con->rx_tail)
                     break;  /* Ring full */
@@ -180,11 +270,14 @@ void virtio_console_process(struct virtio_console_shm *con)
             con->rx_head = head;
             __sync_synchronize();
         } else if (n == 0) {
+            printf("[Backend] Console TCP client disconnected\n");
             close(client_fd);
             client_fd = -1;
+            iac_state = 0;  /* Reset IAC state for next client */
         } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
             close(client_fd);
             client_fd = -1;
+            iac_state = 0;
         }
     }
 }

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/guest_partition/rootfs_overlay/etc/init.d/S99virtio_guest
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/guest_partition/rootfs_overlay/etc/init.d/S99virtio_guest
@@ -4,6 +4,21 @@
 # Spawns getty on ttyS1 (COM2) for host telnet at port 4321.
 # Spawns getty on /dev/hvc0 (virtio console) for System telnet at port 4321.
 #
+# Getty processes are respawned automatically when they exit (e.g., after
+# a user logs out), so subsequent telnet connections always find a live
+# login prompt.
+#
+
+# Respawn getty in an infinite loop.  When getty exits (user logout, ^D,
+# or error), sleep briefly to avoid busy-loop on persistent failures,
+# then restart.  This ensures every new telnet connection sees a fresh
+# login prompt.
+respawn_getty() {
+    while true; do
+        /sbin/getty "$@"
+        sleep 1
+    done
+}
 
 case "$1" in
     start)
@@ -18,7 +33,7 @@ case "$1" in
             /opt/set_serial_poll /dev/ttyS1 2>/dev/null
             # Send a marker to verify COM2 output works
             echo "COM2_READY" > /dev/ttyS1 2>/dev/null
-            /sbin/getty -L ttyS1 115200 vt100 &
+            respawn_getty -L ttyS1 115200 vt100 &
             echo "getty on ttyS1 started (host telnet localhost 4321)"
         fi
 
@@ -45,7 +60,7 @@ case "$1" in
             (
                 for _w in $(seq 1 30); do
                     if [ -e /dev/hvc0 ]; then
-                        /sbin/getty -L hvc0 115200 vt100 &
+                        respawn_getty -L hvc0 115200 vt100 &
                         echo "getty on /dev/hvc0 started (System telnet 127.0.0.1 4321)"
                         break
                     fi

--- a/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/src/virtio_console.c
+++ b/user/bail/examples/virtio_linux_demo_2p_amd64/system_partition/src/virtio_console.c
@@ -40,6 +40,19 @@
 static int listen_fd = -1;
 static int client_fd = -1;
 
+/*
+ * Telnet IAC state machine - persists across read() calls to handle
+ * IAC sequences split across TCP segment boundaries.
+ *
+ * States:
+ *   0 = normal data
+ *   1 = received IAC (0xFF), waiting for command byte
+ *   2 = received IAC + WILL/WONT/DO/DONT, waiting for option byte
+ *   3 = inside IAC SB subnegotiation, scanning for IAC
+ *   4 = inside IAC SB subnegotiation, received IAC, waiting for SE
+ */
+static int iac_state = 0;
+
 void virtio_console_init(struct virtio_console_shm *con)
 {
     struct sockaddr_in addr;
@@ -130,16 +143,16 @@ void virtio_console_process(struct virtio_console_shm *con)
             (void)write(fd, telnet_init, sizeof(telnet_init));
 
             client_fd = fd;
+            iac_state = 0;  /* Reset IAC parser for new client */
             printf("[Backend] Console TCP client connected\n");
 
-            /* Inject a newline into the Guest's RX buffer.  getty has
-             * likely already printed the login prompt before the TCP
-             * client connected, so the prompt was consumed (sent to
-             * stdout only).  A newline causes getty to see an empty
-             * username and re-display "login:", which is now forwarded
-             * to the freshly connected TCP client. */
+            /* Inject newline to make getty re-display login prompt.
+             * Getty has already printed the initial prompt before the
+             * TCP client connected, so it was consumed (sent to stdout
+             * only).  A newline causes getty to see an empty username
+             * and re-display "login:", which goes to the TCP client. */
+            __sync_synchronize();
             {
-                __sync_synchronize();
                 uint32_t rx_h = con->rx_head;
                 uint32_t rx_next = (rx_h + 1) % con->buf_size;
                 if (rx_next != con->rx_tail) {
@@ -184,11 +197,70 @@ void virtio_console_process(struct virtio_console_shm *con)
             head = con->rx_head;
             for (ssize_t i = 0; i < n; i++) {
                 unsigned char ch = (unsigned char)buf[i];
-                /* Filter telnet IAC sequences (IAC + cmd + option = 3 bytes) */
-                if (ch == TELNET_IAC) {
-                    i += 2;  /* skip command and option bytes */
+
+                /* Telnet IAC state machine — handles sequences split
+                 * across read() boundaries.  States:
+                 *   0: normal data
+                 *   1: after IAC, waiting for command byte
+                 *   2: after IAC WILL/WONT/DO/DONT, waiting for option
+                 *   3: inside SB subnegotiation, scanning for IAC
+                 *   4: inside SB subneg, got IAC, waiting for SE
+                 *
+                 * Without this, partial IAC sequences or SB subneg
+                 * data (e.g. NAWS window-size bytes) leak into the
+                 * guest PTY, potentially killing getty via SIGINT. */
+                if (iac_state == 3) {
+                    /* Inside SB subnegotiation: discard data until IAC */
+                    if (ch == TELNET_IAC)
+                        iac_state = 4;
                     continue;
                 }
+                if (iac_state == 4) {
+                    /* SB subneg saw IAC: expect SE(240) to end */
+                    if (ch == 240) {
+                        iac_state = 0;  /* SE: subneg complete */
+                    } else if (ch == TELNET_IAC) {
+                        iac_state = 4;  /* IAC IAC inside SB: escaped 0xFF, stay */
+                    } else {
+                        iac_state = 3;  /* Not SE: back to scanning */
+                    }
+                    continue;
+                }
+                if (iac_state == 1) {
+                    /* After IAC: expect command byte */
+                    if (ch == TELNET_IAC) {
+                        /* IAC IAC = escaped literal 0xFF */
+                        iac_state = 0;
+                        uint32_t next_head = (head + 1) % con->buf_size;
+                        if (next_head == con->rx_tail)
+                            break;
+                        con->rx_buf[head] = (char)0xFF;
+                        head = next_head;
+                    } else if (ch >= TELNET_WILL && ch <= TELNET_DONT) {
+                        /* WILL(251)/WONT(252)/DO(253)/DONT(254):
+                         * 3-byte sequence, need option byte next */
+                        iac_state = 2;
+                    } else if (ch == 250) {
+                        /* SB(250): subnegotiation start, discard until IAC SE */
+                        iac_state = 3;
+                    } else {
+                        /* Other IAC commands (NOP, BRK, IP, etc.):
+                         * 2-byte sequence, done */
+                        iac_state = 0;
+                    }
+                    continue;
+                }
+                if (iac_state == 2) {
+                    /* After IAC + cmd: this is the option byte, skip it */
+                    iac_state = 0;
+                    continue;
+                }
+                if (ch == TELNET_IAC) {
+                    iac_state = 1;
+                    continue;
+                }
+
+                /* Normal data byte */
                 uint32_t next_head = (head + 1) % con->buf_size;
                 if (next_head == con->rx_tail)
                     break;  /* Ring full */
@@ -201,9 +273,11 @@ void virtio_console_process(struct virtio_console_shm *con)
             printf("[Backend] Console TCP client disconnected\n");
             close(client_fd);
             client_fd = -1;
+            iac_state = 0;  /* Reset IAC state for next client */
         } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
             close(client_fd);
             client_fd = -1;
+            iac_state = 0;
         }
     }
 }

--- a/user/bail/examples/virtio_linux_demo_2p_riscv64/guest_partition/rootfs_overlay/etc/init.d/S99virtio_guest
+++ b/user/bail/examples/virtio_linux_demo_2p_riscv64/guest_partition/rootfs_overlay/etc/init.d/S99virtio_guest
@@ -4,6 +4,17 @@
 # Starts Virtio Frontend daemon and spawns getty on /dev/hvc0 (PTY via shared memory).
 # Guest console accessible from System partition: telnet 127.0.0.1 4321
 #
+# Getty is respawned automatically when it exits (e.g., after user logout),
+# so subsequent telnet connections always find a live login prompt.
+#
+
+# Respawn getty in an infinite loop.
+respawn_getty() {
+    while true; do
+        /sbin/getty "$@"
+        sleep 1
+    done
+}
 
 case "$1" in
     start)
@@ -39,7 +50,7 @@ case "$1" in
                 tries=$((tries - 1))
             done
             if [ -e /dev/hvc0 ]; then
-                /sbin/getty -L hvc0 115200 vt100 &
+                respawn_getty -L hvc0 115200 vt100 &
             fi
         ) &
         ;;

--- a/user/bail/examples/virtio_linux_demo_2p_riscv64/system_partition/src/virtio_console.c
+++ b/user/bail/examples/virtio_linux_demo_2p_riscv64/system_partition/src/virtio_console.c
@@ -1,7 +1,7 @@
 /*
  * virtio_console.c - Virtio Console backend for PRTOS System Partition.
  *
- * Uses the Virtio_Con shared memory region (256KB).
+ * Uses the Virtio_Con shared memory region at GPA 0x16500000 (256KB).
  *
  * Data flow (bidirectional):
  *   Guest writes to /dev/hvc0 -> tx_buf in shared memory -> Backend reads
@@ -39,6 +39,19 @@
 
 static int listen_fd = -1;
 static int client_fd = -1;
+
+/*
+ * Telnet IAC state machine - persists across read() calls to handle
+ * IAC sequences split across TCP segment boundaries.
+ *
+ * States:
+ *   0 = normal data
+ *   1 = received IAC (0xFF), waiting for command byte
+ *   2 = received IAC + WILL/WONT/DO/DONT, waiting for option byte
+ *   3 = inside IAC SB subnegotiation, scanning for IAC
+ *   4 = inside IAC SB subnegotiation, received IAC, waiting for SE
+ */
+static int iac_state = 0;
 
 void virtio_console_init(struct virtio_console_shm *con)
 {
@@ -130,6 +143,24 @@ void virtio_console_process(struct virtio_console_shm *con)
             (void)write(fd, telnet_init, sizeof(telnet_init));
 
             client_fd = fd;
+            iac_state = 0;  /* Reset IAC parser for new client */
+            printf("[Backend] Console TCP client connected\n");
+
+            /* Inject newline to make getty re-display login prompt.
+             * Getty has already printed the initial prompt before the
+             * TCP client connected, so it was consumed (sent to stdout
+             * only).  A newline causes getty to see an empty username
+             * and re-display "login:", which goes to the TCP client. */
+            __sync_synchronize();
+            {
+                uint32_t rx_h = con->rx_head;
+                uint32_t rx_next = (rx_h + 1) % con->buf_size;
+                if (rx_next != con->rx_tail) {
+                    con->rx_buf[rx_h] = '\n';
+                    con->rx_head = rx_next;
+                    __sync_synchronize();
+                }
+            }
         }
     }
 
@@ -166,11 +197,70 @@ void virtio_console_process(struct virtio_console_shm *con)
             head = con->rx_head;
             for (ssize_t i = 0; i < n; i++) {
                 unsigned char ch = (unsigned char)buf[i];
-                /* Filter telnet IAC sequences (IAC + cmd + option = 3 bytes) */
-                if (ch == TELNET_IAC) {
-                    i += 2;  /* skip command and option bytes */
+
+                /* Telnet IAC state machine — handles sequences split
+                 * across read() boundaries.  States:
+                 *   0: normal data
+                 *   1: after IAC, waiting for command byte
+                 *   2: after IAC WILL/WONT/DO/DONT, waiting for option
+                 *   3: inside SB subnegotiation, scanning for IAC
+                 *   4: inside SB subneg, got IAC, waiting for SE
+                 *
+                 * Without this, partial IAC sequences or SB subneg
+                 * data (e.g. NAWS window-size bytes) leak into the
+                 * guest PTY, potentially killing getty via SIGINT. */
+                if (iac_state == 3) {
+                    /* Inside SB subnegotiation: discard data until IAC */
+                    if (ch == TELNET_IAC)
+                        iac_state = 4;
                     continue;
                 }
+                if (iac_state == 4) {
+                    /* SB subneg saw IAC: expect SE(240) to end */
+                    if (ch == 240) {
+                        iac_state = 0;  /* SE: subneg complete */
+                    } else if (ch == TELNET_IAC) {
+                        iac_state = 4;  /* IAC IAC inside SB: escaped 0xFF, stay */
+                    } else {
+                        iac_state = 3;  /* Not SE: back to scanning */
+                    }
+                    continue;
+                }
+                if (iac_state == 1) {
+                    /* After IAC: expect command byte */
+                    if (ch == TELNET_IAC) {
+                        /* IAC IAC = escaped literal 0xFF */
+                        iac_state = 0;
+                        uint32_t next_head = (head + 1) % con->buf_size;
+                        if (next_head == con->rx_tail)
+                            break;
+                        con->rx_buf[head] = (char)0xFF;
+                        head = next_head;
+                    } else if (ch >= TELNET_WILL && ch <= TELNET_DONT) {
+                        /* WILL(251)/WONT(252)/DO(253)/DONT(254):
+                         * 3-byte sequence, need option byte next */
+                        iac_state = 2;
+                    } else if (ch == 250) {
+                        /* SB(250): subnegotiation start, discard until IAC SE */
+                        iac_state = 3;
+                    } else {
+                        /* Other IAC commands (NOP, BRK, IP, etc.):
+                         * 2-byte sequence, done */
+                        iac_state = 0;
+                    }
+                    continue;
+                }
+                if (iac_state == 2) {
+                    /* After IAC + cmd: this is the option byte, skip it */
+                    iac_state = 0;
+                    continue;
+                }
+                if (ch == TELNET_IAC) {
+                    iac_state = 1;
+                    continue;
+                }
+
+                /* Normal data byte */
                 uint32_t next_head = (head + 1) % con->buf_size;
                 if (next_head == con->rx_tail)
                     break;  /* Ring full */
@@ -180,11 +270,14 @@ void virtio_console_process(struct virtio_console_shm *con)
             con->rx_head = head;
             __sync_synchronize();
         } else if (n == 0) {
+            printf("[Backend] Console TCP client disconnected\n");
             close(client_fd);
             client_fd = -1;
+            iac_state = 0;  /* Reset IAC state for next client */
         } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
             close(client_fd);
             client_fd = -1;
+            iac_state = 0;
         }
     }
 }


### PR DESCRIPTION
Root cause: respawn_getty()incorrectly reordered BusyBox getty arguments, placing the device name at the end (/sbin/getty -L 115200 vt100 hvc0) instead of the correct order (device name first: /sbin/getty -L hvc0 115200 vt100). This caused BusyBox to attempt opening /dev/115200instead of /dev/hvc0, resulting in immediate getty startup failures and continuous respawning, with no data ever flowing through the console shared memory.

Fix applied:
 1. Updated S99virtio_guestto correct the argument-passing logic in respawn_getty()to pass all arguments as-is (/sbin/getty "$@").
 2. Adjusted all call sites to maintain the same argument order as the original one-shot getty (respawn_getty -L hvc0 115200 vt100).
 3. Simplified virtio_console.cto revert to immediate newline injection (the deferred mechanism was not the root cause, but immediate injection is cleaner).

Impact: Fix applied uniformly across amd64, aarch64, and riscv64 platforms.